### PR TITLE
ffmpeg version command that doesn't produce an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Going forward I would like to look into [SlimerJS](https://slimerjs.org/) instea
 
 First install PhantomJS with `npm install phantomjs-prebuilt -g` or `yarn global add phantomjs-prebuilt`. You can check if it's installed with `phantomjs -v`.
 
-For Mac users, install ffmpeg with `brew install ffmpeg`. You can check if it's installed with `ffmpeg -v`. I'm not sure how you'd install ffmpeg on Windows or Linux, so you are on your own.
+For Mac users, install ffmpeg with `brew install ffmpeg`. You can check if it's installed with `ffmpeg -version`. I'm not sure how you'd install ffmpeg on Windows or Linux, so you are on your own.
 
 Then run `npm install` or `yarn install`. This will automatically run `browserify public/packages.js > public/packages.combined.js` after it installs all of the Node dependencies - see `package.js`.
 


### PR DESCRIPTION
looks like `ffmpeg -version` is the correct command

[http://superuser.com/questions/407682/how-to-check-my-current-version-of-ffmpeg](http://superuser.com/questions/407682/how-to-check-my-current-version-of-ffmpeg)

before:
<img width="1065" alt="screen shot 2016-12-03 at 7 37 21 pm" src="https://cloud.githubusercontent.com/assets/2119400/20863876/f3d30868-b98f-11e6-9557-543a95e9d2c4.png">

after:
<img width="1072" alt="screen shot 2016-12-03 at 7 37 49 pm" src="https://cloud.githubusercontent.com/assets/2119400/20863878/0224283e-b990-11e6-8e05-511fabeebd0c.png">

